### PR TITLE
perf: Export sha256 from ark_crypto_primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,12 @@ version = 4
 
 [[package]]
 name = "ahash"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
+name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
@@ -20,6 +26,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ark-bls12-377"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc41c02c0d18a226947ee9ee023b1d957bdb6a68fc22ac296722935a9fef423c"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -41,6 +58,8 @@ checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-nonnative-field",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-snark",
@@ -49,26 +68,6 @@ dependencies = [
  "derivative",
  "digest 0.9.0",
  "rayon",
-]
-
-[[package]]
-name = "ark-crypto-primitives"
-version = "0.3.0"
-source = "git+ssh://git@github.com/BarbacoviF/crypto-primitives.git?branch=pcd_deps_plus_sha#f67cd2053267466cfdde8100b34bc426808de2b3"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-nonnative-field",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "ark-sponge",
- "ark-std",
- "blake2",
- "derivative",
- "digest 0.9.0",
- "sha2 0.9.9",
  "tracing",
 ]
 
@@ -85,6 +84,30 @@ dependencies = [
  "num-traits",
  "rayon",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ed-on-mnt4-298"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1be7a14845fea5212e3184f969ed7213cdc118f1e74ce78825426558fbe4825"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-mnt4-298",
+ "ark-std",
 ]
 
 [[package]]
@@ -129,19 +152,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-gm17"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94713045868e99a606a89825ff5a901667ba707ad1966a32c7f3a4d4dbcc0e9a"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "tracing",
+]
+
+[[package]]
 name = "ark-groth16"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f8fff7468e947130b5caf9bdd27de8b913cf30e15104b4f0cd301726b3d897"
 dependencies = [
- "ark-crypto-primitives 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",
  "ark-poly",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-std",
+ "derivative",
  "rayon",
+ "tracing",
+]
+
+[[package]]
+name = "ark-marlin"
+version = "0.1.0"
+source = "git+https://github.com/arkworks-rs/marlin?branch=vlopes11%2Fconstraints#c25470345203ad710cdc5bd497b5f680962e27ec"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-poly",
+ "ark-poly-commit",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-sponge",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "hashbrown 0.9.1",
+ "rand_chacha",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ark-mnt4-298"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad641dc1498d0dfe8d1af35bd773752fd85b9ca1ce4d5c652cc88ca1bc2c5df1"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-mnt4-753"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ee523df86e85ee075f98f2f61998591d2d456487b32fefe228d2c5a22173c4"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-mnt6-298"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82335122b96dd416b69ec209ae156fc5995d030b62e4cd829a266b1b460c5ac3"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-mnt4-298",
+ "ark-r1cs-std",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-mnt6-753"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fba0d19324bf7424512700ab4f1a9adbe990a6a0cc0bbce88f0868a045cacb7"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-mnt4-753",
+ "ark-r1cs-std",
+ "ark-std",
 ]
 
 [[package]]
@@ -163,6 +282,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-pcd"
+version = "0.1.0"
+source = "git+https://github.com/BarbacoviF/pcd.git?branch=barbacovif%2Fuse-short-weierstrass-curve#1bd8f435cfaff4dff65680270128a035cbbe4d2c"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ed-on-bls12-381",
+ "ark-ed-on-mnt4-298",
+ "ark-ff",
+ "ark-gm17",
+ "ark-groth16",
+ "ark-marlin",
+ "ark-mnt4-298",
+ "ark-mnt6-298",
+ "ark-nonnative-field",
+ "ark-poly",
+ "ark-poly-commit",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "derivative",
+ "rand_chacha",
+ "tracing",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,8 +319,28 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "hashbrown",
+ "hashbrown 0.11.2",
  "rayon",
+]
+
+[[package]]
+name = "ark-poly-commit"
+version = "0.3.1"
+source = "git+https://github.com/arkworks-rs/poly-commit?branch=constraints#a688fe93082abdf3f651a8af55ce1e4b8da38410"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-nonnative-field",
+ "ark-poly",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-sponge",
+ "ark-std",
+ "derivative",
+ "digest 0.9.0",
+ "hashbrown 0.9.1",
+ "tracing",
 ]
 
 [[package]]
@@ -287,26 +454,33 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bitcoin_r1cs"
 version = "0.1.0"
 dependencies = [
+ "ark-bls12-377",
  "ark-bls12-381",
- "ark-crypto-primitives 0.3.0 (git+ssh://git@github.com/BarbacoviF/crypto-primitives.git?branch=pcd_deps_plus_sha)",
+ "ark-crypto-primitives",
+ "ark-ec",
  "ark-ff",
  "ark-groth16",
+ "ark-mnt4-753",
+ "ark-mnt6-753",
+ "ark-pcd",
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
+ "ark-std",
  "byteorder",
  "chain-gang",
  "hex",
  "rand",
  "rand_chacha",
+ "sha2",
 ]
 
 [[package]]
@@ -318,15 +492,6 @@ dependencies = [
  "crypto-mac",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -376,7 +541,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2 0.10.8",
+ "sha2",
  "snowflake",
  "typenum",
 ]
@@ -389,9 +554,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -495,7 +660,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -597,11 +762,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -635,7 +809,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2",
  "signature",
 ]
 
@@ -659,9 +833,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -705,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "opaque-debug"
@@ -769,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -894,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "sec1"
@@ -947,14 +1121,14 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -971,19 +1145,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -1052,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1078,7 +1239,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1100,7 +1261,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1136,15 +1297,15 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1315,7 +1476,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1335,5 +1496,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2024"
 
 [dependencies]
 ark-bls12-381 = "0.3.0"
-ark-crypto-primitives = { git = "ssh://git@github.com/BarbacoviF/crypto-primitives.git", version = "0.3.0", branch = "pcd_deps_plus_sha", features = ["r1cs"] }
+ark-crypto-primitives = { version = "0.3.0", features = ["r1cs"] }
+ark-ec = "0.3.0"
 ark-ff = { version = "0.3.0", features = ["std"] }
-ark-groth16 = "0.3.0"
+ark-groth16 = {version = "0.3.0", features = ["r1cs"]}
 ark-r1cs-std = "0.3.0"
 ark-relations = "0.3.0"
 ark-serialize = "0.3.0"
@@ -16,3 +17,10 @@ chain_gang = { git = "https://github.com/nchain-innovation/chain-gang.git", tag 
 hex = "0.4.3"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+
+ark-pcd = { git = "https://github.com/BarbacoviF/pcd.git", branch = "barbacovif/use-short-weierstrass-curve", version = "0.1.0" }
+ark-mnt4-753 = {version = "0.3.0", features = ["r1cs"]}
+ark-mnt6-753 = {version = "0.3.0", features = ["r1cs"]}
+ark-std = "0.3.0"
+sha2 = "0.10.8"
+ark-bls12-377 = "0.3.0"

--- a/src/bitcoin_predicates/data_structures/mod.rs
+++ b/src/bitcoin_predicates/data_structures/mod.rs
@@ -1,0 +1,3 @@
+pub mod bitcoin_proof;
+pub mod bitcoin_unit;
+pub mod byte_vector;

--- a/src/bitcoin_predicates/mod.rs
+++ b/src/bitcoin_predicates/mod.rs
@@ -1,0 +1,4 @@
+pub mod data_structures;
+pub mod fixed_lock_script;
+pub mod pay_to_utxo;
+pub mod prevent_replay_attacks;

--- a/src/constraints/hash256.rs
+++ b/src/constraints/hash256.rs
@@ -1,8 +1,8 @@
 //! R1CS implemenation of double Sha256
 use std::marker::PhantomData;
 
-use ark_crypto_primitives::crh::sha256::constraints::DigestVar;
-use ark_crypto_primitives::crh::sha256::constraints::Sha256Gadget;
+use crate::sha256::constraints::DigestVar;
+use crate::sha256::constraints::Sha256Gadget;
 use ark_ff::PrimeField;
 use ark_r1cs_std::uint8::UInt8;
 use ark_relations::r1cs::Result;

--- a/src/constraints/outpoint.rs
+++ b/src/constraints/outpoint.rs
@@ -7,7 +7,7 @@ use ark_r1cs_std::{
     uint32::UInt32,
 };
 
-use ark_crypto_primitives::crh::sha256::constraints::DigestVar;
+use crate::sha256::constraints::DigestVar;
 
 use crate::traits::PreSigHashSerialise;
 use ark_relations::r1cs::{Namespace, SynthesisError};

--- a/src/constraints/sighash_cache.rs
+++ b/src/constraints/sighash_cache.rs
@@ -1,4 +1,4 @@
-use ark_crypto_primitives::crh::sha256::constraints::DigestVar;
+use crate::sha256::constraints::DigestVar;
 use ark_ff::PrimeField;
 
 /// R1CS version of [SigHashCache](chain_gang::transaction::sighash::SigHashCache)

--- a/src/constraints/tx.rs
+++ b/src/constraints/tx.rs
@@ -1,5 +1,5 @@
 //! Implementation of [TxVar], R1CS version of a Bitcoin [Tx]
-use ark_crypto_primitives::crh::sha256::constraints::DigestVar;
+use crate::sha256::constraints::DigestVar;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     R1CSVar,
@@ -178,10 +178,10 @@ impl<F: PrimeField, P: TxVarConfig + Clone> TxVar<F, P> {
 
         let mut ser: Vec<UInt8<F>> = Vec::new();
         ser.extend_from_slice(version.as_slice());
-        ser.extend_from_slice(cache.hash_prevouts().unwrap().to_bytes()?.as_slice());
-        ser.extend_from_slice(cache.hash_sequence().unwrap().to_bytes()?.as_slice());
+        ser.extend_from_slice(cache.hash_prevouts.as_ref().unwrap().to_bytes()?.as_slice());
+        ser.extend_from_slice(cache.hash_sequence.as_ref().unwrap().to_bytes()?.as_slice());
         ser.extend_from_slice(input_specific_serialisation.as_slice());
-        ser.extend_from_slice(cache.hash_outputs().unwrap().to_bytes()?.as_slice());
+        ser.extend_from_slice(cache.hash_outputs.as_ref().unwrap().to_bytes()?.as_slice());
         ser.extend_from_slice(lock_time.as_slice());
         ser.extend_from_slice(
             UInt32::<F>::constant((SIGHASH_FORKID | sighash_flags) as u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@
 
 /// R1CS version of Bitcoin structures
 pub mod constraints;
+/// Export Sha256 R1CS constaints. This is taken from [ark_crypto_primitives]. It was the easiest
+/// solution to avoid breaking dependencies
+pub mod sha256;
 
 pub mod traits;
 pub mod util;

--- a/src/reftx.rs
+++ b/src/reftx.rs
@@ -1,0 +1,205 @@
+use ark_ff::PrimeField;
+use ark_r1cs_std::{alloc::AllocVar, uint64::UInt64};
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+use chain_gang::{messages::Tx, script::Script, transaction::sighash::SigHashCache};
+
+use crate::{
+    constraints::{
+        script::ScriptVar,
+        sighash_cache::SigHashCacheVar,
+        tx::{TxVar, TxVarConfig},
+    },
+    traits::BitcoinPredicate,
+    transaction_integrity_gadget::{
+        TransactionIntegrityConfig, TransactionIntegrityTag,
+        constraints::{TransactionIntegrityGadget, TransactionIntegrityTagVar},
+    },
+    util::default_tx,
+};
+
+pub struct RefTxCircuit<
+    B: BitcoinPredicate<F, P>,
+    F: PrimeField + Clone,
+    P: TxVarConfig + TransactionIntegrityConfig + Clone,
+> {
+    /// Public inputs
+    pub locking_data: B::LockingData,
+    pub unlocking_data: B::UnlockingData,
+    pub integrity_tag: Option<TransactionIntegrityTag>,
+    /// Witness values
+    pub witness: B::Witness,
+    pub spending_data: Option<Tx>,
+    pub prev_lock_script: Option<Script>,
+    pub prev_amount: Option<u64>,
+    pub sighash_cache: Option<SigHashCache>,
+    /// Predicate
+    pub predicate: B,
+}
+
+impl<B, F, P> ConstraintSynthesizer<F> for RefTxCircuit<B, F, P>
+where
+    B: BitcoinPredicate<F, P>,
+    F: PrimeField + Clone,
+    P: TxVarConfig + TransactionIntegrityConfig + Clone,
+{
+    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+        // Allocate the inputs
+        let locking_data: B::LockingDataVar =
+            B::LockingDataVar::new_input(cs.clone(), || Ok(self.locking_data))?;
+        let unlocking_data: B::UnlockingDataVar =
+            B::UnlockingDataVar::new_input(cs.clone(), || Ok(self.unlocking_data))?;
+        let integrity_tag: TransactionIntegrityTagVar<F> =
+            TransactionIntegrityTagVar::<F>::new_input(cs.clone(), || {
+                Ok(self.integrity_tag.unwrap_or_default())
+            })?;
+        // Allocate the witnesses
+        let witness: B::WitnessVar = B::WitnessVar::new_witness(cs.clone(), || Ok(self.witness))?;
+        let spending_data: TxVar<F, P> = TxVar::<F, P>::new_input(cs.clone(), || {
+            Ok(self.spending_data.unwrap_or(default_tx::<P>()))
+        })?;
+        let default_prev_lock_script = Script(vec![0; P::LEN_PREV_LOCK_SCRIPT]);
+        let prev_lock_script: ScriptVar<F> = ScriptVar::<F>::new_witness(cs.clone(), || {
+            Ok(self.prev_lock_script.unwrap_or(default_prev_lock_script))
+        })?;
+        let prev_amount: UInt64<F> =
+            UInt64::<F>::new_witness(cs.clone(), || Ok(self.prev_amount.unwrap_or(0)))?;
+        let mut sighash_cache: SigHashCacheVar<F> =
+            SigHashCacheVar::<F>::new_witness(cs.clone(), || {
+                Ok(self.sighash_cache.unwrap_or_default())
+            })?;
+
+        // Enforce the integrity of the tag
+        TransactionIntegrityGadget::<F, P>::verify(
+            cs.clone(),
+            &spending_data,
+            &prev_lock_script,
+            &prev_amount,
+            &mut sighash_cache,
+            &integrity_tag,
+        )?;
+
+        // Enforce the predicate
+        self.predicate.enforce_constraints(
+            cs.clone(),
+            &locking_data,
+            &unlocking_data,
+            &spending_data,
+            &witness,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_bls12_381::Fr as F;
+
+    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
+    use chain_gang::address::addr_decode;
+    use chain_gang::script::Script;
+    use chain_gang::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID, SigHashCache};
+
+    use chain_gang::messages::{OutPoint, Tx, TxIn, TxOut};
+    use chain_gang::network::Network;
+    use chain_gang::transaction::p2pkh;
+    use chain_gang::util::Hash256;
+
+    use crate::bitcoin_predicates::data_structures::bitcoin_unit::BitcoinUnit;
+    use crate::bitcoin_predicates::fixed_lock_script::FixedLockScript;
+    use crate::constraints::tx::TxVarConfig;
+    use crate::transaction_integrity_gadget::{
+        TransactionIntegrityConfig, TransactionIntegrityScheme,
+    };
+
+    use super::RefTxCircuit;
+
+    type TestPredicate = FixedLockScript<F, Config>;
+
+    #[derive(Clone)]
+    struct Config;
+    impl TxVarConfig for Config {
+        const N_INPUTS: usize = 1;
+        const N_OUTPUTS: usize = 2;
+        const LEN_UNLOCK_SCRIPTS: &[usize] = &[0];
+        const LEN_LOCK_SCRIPTS: &[usize] = &[0x19, 0x19];
+    }
+
+    impl TransactionIntegrityConfig for Config {
+        const N_INPUT: usize = 0;
+        const LEN_PREV_LOCK_SCRIPT: usize = 0x00;
+        const SIGHASH_FLAG: u8 = SIGHASH_ALL | SIGHASH_FORKID;
+    }
+
+    fn test_reftx(addr: &str, lock_script: Script, expected: bool) {
+        let hash160 = addr_decode(addr, Network::BSV_Testnet).unwrap().0;
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: Hash256::decode(
+                        "f671dc000ad12795e86b59b27e0c367d9b026bbd4141c227b9285867a53bb6f7",
+                    )
+                    .unwrap(),
+                    index: 0,
+                },
+                unlock_script: Script(vec![]),
+                sequence: 0,
+            }],
+            outputs: vec![
+                TxOut {
+                    satoshis: 100,
+                    lock_script: lock_script,
+                },
+                TxOut {
+                    satoshis: 259899900,
+                    lock_script: p2pkh::create_lock_script(&hash160),
+                },
+            ],
+            lock_time: 0,
+        };
+        let mut cache = SigHashCache::new();
+
+        let tag = TransactionIntegrityScheme::<Config>::commit(
+            &tx.clone(),
+            &Script(vec![]),
+            260000,
+            &mut cache,
+        );
+        let test_predicate = TestPredicate::new(p2pkh::create_lock_script(&hash160), 0);
+        let test_circuit = RefTxCircuit::<TestPredicate, F, Config> {
+            locking_data: BitcoinUnit::default(),
+            unlocking_data: BitcoinUnit::default(),
+            integrity_tag: Some(tag),
+            witness: BitcoinUnit::default(),
+            spending_data: Some(tx),
+            prev_lock_script: Some(Script(vec![])),
+            prev_amount: Some(260000),
+            sighash_cache: None,
+            predicate: test_predicate,
+        };
+
+        let cs = ConstraintSystem::<F>::new_ref();
+        test_circuit.generate_constraints(cs.clone()).unwrap();
+        let is_satisfied = cs.is_satisfied().unwrap();
+
+        assert_eq!(is_satisfied, expected);
+    }
+
+    #[test]
+    fn test_reftx_is_ok() {
+        let addr = "mfmKD4cP6Na7T8D87XRSiR7shA1HNGSaec";
+        let hash160 = addr_decode(addr, Network::BSV_Testnet).unwrap().0;
+        let lock_script = p2pkh::create_lock_script(&hash160);
+        test_reftx(addr, lock_script, true);
+    }
+
+    #[test]
+    fn test_reftx_fails() {
+        let addr = "mfmKD4cP6Na7T8D87XRSiR7shA1HNGSaec";
+        let wrong_addr = "mzXd2pQG2dbgK9trYAZcpKycWDEfjVbeMz";
+        let hash160 = addr_decode(wrong_addr, Network::BSV_Testnet).unwrap().0;
+        let lock_script = p2pkh::create_lock_script(&hash160);
+        test_reftx(addr, lock_script, false);
+    }
+}

--- a/src/sha256/constraints.rs
+++ b/src/sha256/constraints.rs
@@ -1,0 +1,509 @@
+// This file was adapted from
+// https://github.com/nanpuyue/sha256/blob/bf6656b7dc72e76bb617445a8865f906670e585b/src/lib.rs
+// See LICENSE-MIT in the root directory for a copy of the license
+// Thank you!
+
+use crate::sha256::{Sha256Wrapper, r1cs_utils::UInt32Ext};
+use ark_crypto_primitives::crh::{CRHGadget, TwoToOneCRHGadget};
+
+use core::{borrow::Borrow, iter, marker::PhantomData};
+
+use ark_ff::PrimeField;
+use ark_r1cs_std::{
+    R1CSVar,
+    alloc::{AllocVar, AllocationMode},
+    bits::{ToBytesGadget, boolean::Boolean, uint8::UInt8, uint32::UInt32},
+    eq::EqGadget,
+    select::CondSelectGadget,
+};
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+use ark_std::{vec, vec::Vec};
+
+const STATE_LEN: usize = 8;
+
+type State = [u32; STATE_LEN];
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const H: State = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+#[derive(Clone)]
+pub struct Sha256Gadget<ConstraintF: PrimeField> {
+    state: Vec<UInt32<ConstraintF>>,
+    completed_data_blocks: u64,
+    pending: Vec<UInt8<ConstraintF>>,
+    num_pending: usize,
+}
+
+impl<ConstraintF: PrimeField> Default for Sha256Gadget<ConstraintF> {
+    fn default() -> Self {
+        Self {
+            state: H.iter().cloned().map(UInt32::constant).collect(),
+            completed_data_blocks: 0,
+            pending: iter::repeat(0u8).take(64).map(UInt8::constant).collect(),
+            num_pending: 0,
+        }
+    }
+}
+
+// Wikipedia's pseudocode is a good companion for understanding the below
+// https://en.wikipedia.org/wiki/SHA-2#Pseudocode
+impl<ConstraintF: PrimeField> Sha256Gadget<ConstraintF> {
+    fn update_state(
+        state: &mut [UInt32<ConstraintF>],
+        data: &[UInt8<ConstraintF>],
+    ) -> Result<(), SynthesisError> {
+        assert_eq!(data.len(), 64);
+
+        let mut w = vec![UInt32::constant(0); 64];
+        for (word, chunk) in w.iter_mut().zip(data.chunks(4)) {
+            *word = UInt32::from_bytes_be(chunk)?;
+        }
+
+        for i in 16..64 {
+            let s0 = {
+                let x1 = w[i - 15].rotr(7);
+                let x2 = w[i - 15].rotr(18);
+                let x3 = w[i - 15].shr(3);
+                x1.xor(&x2)?.xor(&x3)?
+            };
+            let s1 = {
+                let x1 = w[i - 2].rotr(17);
+                let x2 = w[i - 2].rotr(19);
+                let x3 = w[i - 2].shr(10);
+                x1.xor(&x2)?.xor(&x3)?
+            };
+            w[i] = UInt32::addmany(&[w[i - 16].clone(), s0, w[i - 7].clone(), s1])?;
+        }
+
+        let mut h = state.to_vec();
+        for i in 0..64 {
+            let ch = {
+                let x1 = h[4].bitand(&h[5])?;
+                let x2 = h[4].not().bitand(&h[6])?;
+                x1.xor(&x2)?
+            };
+            let ma = {
+                let x1 = h[0].bitand(&h[1])?;
+                let x2 = h[0].bitand(&h[2])?;
+                let x3 = h[1].bitand(&h[2])?;
+                x1.xor(&x2)?.xor(&x3)?
+            };
+            let s0 = {
+                let x1 = h[0].rotr(2);
+                let x2 = h[0].rotr(13);
+                let x3 = h[0].rotr(22);
+                x1.xor(&x2)?.xor(&x3)?
+            };
+            let s1 = {
+                let x1 = h[4].rotr(6);
+                let x2 = h[4].rotr(11);
+                let x3 = h[4].rotr(25);
+                x1.xor(&x2)?.xor(&x3)?
+            };
+            let t0 =
+                UInt32::addmany(&[h[7].clone(), s1, ch, UInt32::constant(K[i]), w[i].clone()])?;
+            let t1 = UInt32::addmany(&[s0, ma])?;
+
+            h[7] = h[6].clone();
+            h[6] = h[5].clone();
+            h[5] = h[4].clone();
+            h[4] = UInt32::addmany(&[h[3].clone(), t0.clone()])?;
+            h[3] = h[2].clone();
+            h[2] = h[1].clone();
+            h[1] = h[0].clone();
+            h[0] = UInt32::addmany(&[t0, t1])?;
+        }
+
+        for (s, hi) in state.iter_mut().zip(h.iter()) {
+            *s = UInt32::addmany(&[s.clone(), hi.clone()])?;
+        }
+
+        Ok(())
+    }
+
+    /// Consumes the given data and updates the internal state
+    pub fn update(&mut self, data: &[UInt8<ConstraintF>]) -> Result<(), SynthesisError> {
+        let mut offset = 0;
+        if self.num_pending > 0 && self.num_pending + data.len() >= 64 {
+            offset = 64 - self.num_pending;
+            // If the inputted data pushes the pending buffer over the chunk size, process it all
+            self.pending[self.num_pending..].clone_from_slice(&data[..offset]);
+            Self::update_state(&mut self.state, &self.pending)?;
+
+            self.completed_data_blocks += 1;
+            self.num_pending = 0;
+        }
+
+        for chunk in data[offset..].chunks(64) {
+            let chunk_size = chunk.len();
+
+            if chunk_size == 64 {
+                // If it's a full chunk, process it
+                Self::update_state(&mut self.state, chunk)?;
+                self.completed_data_blocks += 1;
+            } else {
+                // Otherwise, add the bytes to the `pending` buffer
+                self.pending[self.num_pending..self.num_pending + chunk_size]
+                    .clone_from_slice(chunk);
+                self.num_pending += chunk_size;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Outputs the final digest of all the inputted data
+    pub fn finalize(mut self) -> Result<DigestVar<ConstraintF>, SynthesisError> {
+        // Encode the number of processed bits as a u64, then serialize it to 8 big-endian bytes
+        let data_bitlen = self.completed_data_blocks * 512 + self.num_pending as u64 * 8;
+        let encoded_bitlen: Vec<UInt8<ConstraintF>> = {
+            let bytes = data_bitlen.to_be_bytes();
+            bytes.iter().map(|&b| UInt8::constant(b)).collect()
+        };
+
+        // Padding starts with a 1 followed by some number of zeros (0x80 = 0b10000000)
+        let mut pending = vec![UInt8::constant(0); 72];
+        pending[0] = UInt8::constant(0x80);
+
+        // We'll either append to the 56+8 = 64 byte boundary or the 120+8 = 128 byte boundary,
+        // depending on whether we have at least 56 unprocessed bytes
+        let offset = if self.num_pending < 56 {
+            56 - self.num_pending
+        } else {
+            120 - self.num_pending
+        };
+
+        // Write the bitlen to the end of the padding. Then process all the padding
+        pending[offset..offset + 8].clone_from_slice(&encoded_bitlen);
+        self.update(&pending[..offset + 8])?;
+
+        // Collect the state into big-endian bytes
+        let bytes: Vec<_> = self.state.iter().flat_map(UInt32::to_bytes_be).collect();
+        Ok(DigestVar(bytes))
+    }
+
+    /// Computes the digest of the given data. This is a shortcut for `default()` followed by
+    /// `update()` followed by `finalize()`.
+    pub fn digest(data: &[UInt8<ConstraintF>]) -> Result<DigestVar<ConstraintF>, SynthesisError> {
+        let mut sha256_var = Self::default();
+        sha256_var.update(data)?;
+        sha256_var.finalize()
+    }
+}
+
+// Now implement the CRH traits for SHA256
+
+/// Contains a 32-byte SHA256 digest
+#[derive(Clone, Debug)]
+pub struct DigestVar<ConstraintF: PrimeField>(pub Vec<UInt8<ConstraintF>>);
+
+impl<ConstraintF> EqGadget<ConstraintF> for DigestVar<ConstraintF>
+where
+    ConstraintF: PrimeField,
+{
+    fn is_eq(&self, other: &Self) -> Result<Boolean<ConstraintF>, SynthesisError> {
+        self.0.is_eq(&other.0)
+    }
+}
+
+impl<ConstraintF: PrimeField> ToBytesGadget<ConstraintF> for DigestVar<ConstraintF> {
+    fn to_bytes(&self) -> Result<Vec<UInt8<ConstraintF>>, SynthesisError> {
+        Ok(self.0.clone())
+    }
+}
+
+impl<ConstraintF: PrimeField> CondSelectGadget<ConstraintF> for DigestVar<ConstraintF>
+where
+    Self: Sized,
+    Self: Clone,
+{
+    fn conditionally_select(
+        cond: &Boolean<ConstraintF>,
+        true_value: &Self,
+        false_value: &Self,
+    ) -> Result<Self, SynthesisError> {
+        let bytes: Result<Vec<_>, _> = true_value
+            .0
+            .iter()
+            .zip(false_value.0.iter())
+            .map(|(t, f)| UInt8::conditionally_select(cond, t, f))
+            .collect();
+        Ok(DigestVar(bytes?))
+    }
+}
+
+/// The unit type for circuit variables. This contains no data.
+#[derive(Clone, Debug, Default)]
+pub struct UnitVar<ConstraintF: PrimeField>(PhantomData<ConstraintF>);
+
+impl<ConstraintF: PrimeField> AllocVar<(), ConstraintF> for UnitVar<ConstraintF> {
+    // Allocates 32 UInt8s
+    fn new_variable<T: Borrow<()>>(
+        _cs: impl Into<Namespace<ConstraintF>>,
+        _f: impl FnOnce() -> Result<T, SynthesisError>,
+        _mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        Ok(UnitVar(PhantomData))
+    }
+}
+
+impl<ConstraintF: PrimeField> AllocVar<Vec<u8>, ConstraintF> for DigestVar<ConstraintF> {
+    // Allocates 32 UInt8s
+    fn new_variable<T: Borrow<Vec<u8>>>(
+        cs: impl Into<Namespace<ConstraintF>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        let cs = cs.into().cs();
+        let native_bytes = f();
+
+        if native_bytes
+            .as_ref()
+            .map(|b| b.borrow().len())
+            .unwrap_or(32)
+            != 32
+        {
+            panic!("DigestVar must be allocated with precisely 32 bytes");
+        }
+
+        // For each i, allocate the i-th byte
+        let var_bytes: Result<Vec<_>, _> = (0..32)
+            .map(|i| {
+                UInt8::new_variable(
+                    cs.clone(),
+                    || native_bytes.as_ref().map(|v| v.borrow()[i]).map_err(|e| *e),
+                    mode,
+                )
+            })
+            .collect();
+
+        Ok(DigestVar(var_bytes?))
+    }
+}
+
+impl<ConstraintF: PrimeField> R1CSVar<ConstraintF> for DigestVar<ConstraintF> {
+    type Value = [u8; 32];
+
+    fn cs(&self) -> ConstraintSystemRef<ConstraintF> {
+        let mut result = ConstraintSystemRef::None;
+        for var in &self.0 {
+            result = var.cs().or(result);
+        }
+        result
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let mut buf = [0u8; 32];
+        for (b, var) in buf.iter_mut().zip(self.0.iter()) {
+            *b = var.value()?;
+        }
+
+        Ok(buf)
+    }
+}
+
+impl<ConstraintF> CRHGadget<Sha256Wrapper, ConstraintF> for Sha256Gadget<ConstraintF>
+where
+    ConstraintF: PrimeField,
+{
+    type OutputVar = DigestVar<ConstraintF>;
+    type ParametersVar = UnitVar<ConstraintF>;
+
+    fn evaluate(
+        _parameters: &Self::ParametersVar,
+        input: &[UInt8<ConstraintF>],
+    ) -> Result<Self::OutputVar, SynthesisError> {
+        Self::digest(input)
+    }
+}
+
+impl<ConstraintF> TwoToOneCRHGadget<Sha256Wrapper, ConstraintF> for Sha256Gadget<ConstraintF>
+where
+    ConstraintF: PrimeField,
+{
+    type OutputVar = DigestVar<ConstraintF>;
+    type ParametersVar = UnitVar<ConstraintF>;
+
+    fn evaluate(
+        _parameters: &Self::ParametersVar,
+        left_input: &[UInt8<ConstraintF>],
+        right_input: &[UInt8<ConstraintF>],
+    ) -> Result<Self::OutputVar, SynthesisError> {
+        let mut h = Self::default();
+        h.update(left_input)?;
+        h.update(right_input)?;
+        h.finalize()
+    }
+}
+
+// All the tests below test against the RustCrypto sha2 implementation
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::sha256::{Sha256Wrapper, digest::Digest};
+    use ark_crypto_primitives::crh::{CRH, CRHGadget, TwoToOneCRH, TwoToOneCRHGadget};
+
+    use ark_bls12_377::Fr;
+    use ark_r1cs_std::R1CSVar;
+    use ark_relations::{
+        ns,
+        r1cs::{ConstraintSystem, Namespace},
+    };
+    use ark_std::rand::RngCore;
+
+    const TEST_LENGTHS: &[usize] = &[
+        0, 1, 2, 8, 20, 40, 55, 56, 57, 63, 64, 65, 90, 100, 127, 128, 129,
+    ];
+
+    /// Witnesses bytes
+    fn to_byte_vars(cs: impl Into<Namespace<Fr>>, data: &[u8]) -> Vec<UInt8<Fr>> {
+        let cs = cs.into().cs();
+        UInt8::new_witness_vec(cs, data).unwrap()
+    }
+
+    /// Finalizes a SHA256 gadget and gets the bytes
+    fn finalize_var(sha256_var: Sha256Gadget<Fr>) -> Vec<u8> {
+        sha256_var.finalize().unwrap().value().unwrap().to_vec()
+    }
+
+    /// Finalizes a native SHA256 struct and gets the bytes
+    fn finalize(sha256: Sha256Wrapper) -> Vec<u8> {
+        sha256.inner.finalize().to_vec()
+    }
+
+    /// Tests the SHA256 of random strings of varied lengths
+    #[test]
+    fn varied_lengths() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        for &len in TEST_LENGTHS {
+            let mut sha256 = Sha256Wrapper::default();
+            let mut sha256_var = Sha256Gadget::default();
+
+            // Make a random string of the given length
+            let mut input_str = vec![0u8; len];
+            rng.fill_bytes(&mut input_str);
+
+            // Compute the hashes and assert consistency
+            sha256_var
+                .update(&to_byte_vars(ns!(cs, "input"), &input_str))
+                .unwrap();
+            sha256.update(input_str.as_slice());
+            assert_eq!(
+                finalize_var(sha256_var),
+                finalize(sha256),
+                "error at length {}",
+                len
+            );
+        }
+    }
+
+    /// Calls `update()` many times
+    #[test]
+    fn many_updates() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let mut sha256 = Sha256Wrapper::default();
+        let mut sha256_var = Sha256Gadget::default();
+
+        // Append the same 7-byte string 20 times
+        for _ in 0..20 {
+            let mut input_str = vec![0u8; 7];
+            rng.fill_bytes(&mut input_str);
+
+            sha256_var
+                .update(&to_byte_vars(ns!(cs, "input"), &input_str))
+                .unwrap();
+            sha256.update(input_str.as_slice());
+        }
+
+        // Make sure the result is consistent
+        assert_eq!(finalize_var(sha256_var), finalize(sha256));
+    }
+
+    /// Tests the CRHCheme trait
+    #[test]
+    fn crh() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        // CRH parameters are nothing
+        let unit = ();
+        let unit_var = UnitVar::default();
+
+        for &len in TEST_LENGTHS {
+            // Make a random string of the given length
+            let mut input_str = vec![0u8; len];
+            rng.fill_bytes(&mut input_str);
+
+            // Compute the hashes and assert consistency
+            let computed_output = <Sha256Gadget<Fr> as CRHGadget<Sha256Wrapper, Fr>>::evaluate(
+                &unit_var,
+                &to_byte_vars(ns!(cs, "input"), &input_str),
+            )
+            .unwrap();
+            let expected_output =
+                <Sha256Wrapper as CRH>::evaluate(&unit, input_str.as_slice()).unwrap();
+            assert_eq!(
+                computed_output.value().unwrap().to_vec(),
+                expected_output,
+                "CRH error at length {}",
+                len
+            )
+        }
+    }
+
+    /// Tests the TwoToOneCRHScheme trait
+    #[test]
+    fn to_to_one_crh() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        // CRH parameters are nothing
+        let unit = ();
+        let unit_var = UnitVar::default();
+
+        for &len in TEST_LENGTHS {
+            // Make random strings of the given length
+            let mut left_input = vec![0u8; len];
+            let mut right_input = vec![0u8; len];
+            rng.fill_bytes(&mut left_input);
+            rng.fill_bytes(&mut right_input);
+
+            // Compute the hashes and assert consistency
+            let computed_output =
+                <Sha256Gadget<Fr> as TwoToOneCRHGadget<Sha256Wrapper, Fr>>::evaluate(
+                    &unit_var,
+                    &to_byte_vars(ns!(cs, "left input"), &left_input),
+                    &to_byte_vars(ns!(cs, "right input"), &right_input),
+                )
+                .unwrap();
+            let expected_output = <Sha256Wrapper as TwoToOneCRH>::evaluate(
+                &unit,
+                left_input.as_slice(),
+                right_input.as_slice(),
+            )
+            .unwrap();
+            assert_eq!(
+                computed_output.value().unwrap().to_vec(),
+                expected_output,
+                "TwoToOneCRH error at length {}",
+                len
+            )
+        }
+    }
+}

--- a/src/sha256/mod.rs
+++ b/src/sha256/mod.rs
@@ -1,0 +1,72 @@
+use ark_crypto_primitives::Error;
+use ark_crypto_primitives::crh::{CRH, TwoToOneCRH};
+
+use ark_std::rand::Rng;
+
+// Re-export the RustCrypto Sha256 type and its associated traits
+pub use sha2::{Sha256, digest};
+
+#[derive(Default)]
+pub struct Sha256Wrapper {
+    pub inner: Sha256,
+}
+
+impl Sha256Wrapper {
+    pub fn update(&mut self, input: &[u8]) {
+        self.inner.update(input);
+    }
+}
+
+mod r1cs_utils;
+
+pub mod constraints;
+
+// Implement the CRH traits for SHA-256
+use sha2::digest::Digest;
+
+impl CRH for Sha256Wrapper {
+    const INPUT_SIZE_BITS: usize = 256; // Dummy - need to have it because of the CRH definition
+
+    // This is always 32 bytes. It has to be a Vec to impl CanonicalSerialize
+    type Output = Vec<u8>;
+    // There are no parameters for SHA256
+    type Parameters = ();
+
+    // There are no parameters for SHA256
+    fn setup<R: Rng>(_rng: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    // Evaluates SHA256(input)
+    fn evaluate(_parameters: &Self::Parameters, input: &[u8]) -> Result<Self::Output, Error> {
+        Ok(Sha256::digest(input).to_vec())
+    }
+}
+
+impl TwoToOneCRH for Sha256Wrapper {
+    const LEFT_INPUT_SIZE_BITS: usize = 256; // Dummy
+    const RIGHT_INPUT_SIZE_BITS: usize = 256; // Dummy
+
+    // This is always 32 bytes. It has to be a Vec to impl CanonicalSerialize
+    type Output = Vec<u8>;
+    // There are no parameters for SHA256
+    type Parameters = ();
+
+    // There are no parameters for SHA256
+    fn setup<R: Rng>(_rng: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    // Evaluates SHA256(left_input || right_input)
+    fn evaluate(
+        _parameters: &Self::Parameters,
+        left_input: &[u8],
+        right_input: &[u8],
+    ) -> Result<Self::Output, Error> {
+        // Process the left input then the right input
+        let mut h = Sha256::default();
+        h.update(left_input);
+        h.update(right_input);
+        Ok(h.finalize().to_vec())
+    }
+}

--- a/src/sha256/r1cs_utils.rs
+++ b/src/sha256/r1cs_utils.rs
@@ -1,0 +1,120 @@
+use ark_ff::PrimeField;
+use ark_r1cs_std::bits::{boolean::Boolean, uint32::UInt32, uint8::UInt8, ToBitsGadget};
+use ark_relations::r1cs::SynthesisError;
+use core::iter;
+
+/// Extra traits not automatically implemented by UInt32
+pub(crate) trait UInt32Ext<ConstraintF: PrimeField>: Sized {
+    /// Right shift
+    fn shr(&self, by: usize) -> Self;
+
+    /// Bitwise NOT
+    fn not(&self) -> Self;
+
+    /// Bitwise AND
+    fn bitand(&self, rhs: &Self) -> Result<Self, SynthesisError>;
+
+    /// Converts from big-endian bytes
+    fn from_bytes_be(bytes: &[UInt8<ConstraintF>]) -> Result<Self, SynthesisError>;
+
+    /// Converts to big-endian bytes
+    fn to_bytes_be(&self) -> Vec<UInt8<ConstraintF>>;
+}
+
+impl<ConstraintF: PrimeField> UInt32Ext<ConstraintF> for UInt32<ConstraintF> {
+    fn shr(&self, by: usize) -> Self {
+        assert!(by < 32);
+
+        let zeros = iter::repeat(Boolean::constant(false)).take(by);
+        let new_bits: Vec<_> = self
+            .to_bits_le()
+            .into_iter()
+            .skip(by)
+            .chain(zeros)
+            .collect();
+        UInt32::from_bits_le(&new_bits)
+    }
+
+    fn not(&self) -> Self {
+        let new_bits: Vec<_> = self.to_bits_le().iter().map(Boolean::not).collect();
+        UInt32::from_bits_le(&new_bits)
+    }
+
+    fn bitand(&self, rhs: &Self) -> Result<Self, SynthesisError> {
+        let new_bits: Result<Vec<_>, SynthesisError> = self
+            .to_bits_le()
+            .into_iter()
+            .zip(rhs.to_bits_le().into_iter())
+            .map(|(a, b)| a.and(&b))
+            .collect();
+        Ok(UInt32::from_bits_le(&new_bits?))
+    }
+
+    fn from_bytes_be(bytes: &[UInt8<ConstraintF>]) -> Result<Self, SynthesisError> {
+        assert_eq!(bytes.len(), 4);
+
+        let mut bits: Vec<Boolean<ConstraintF>> = Vec::new();
+        for byte in bytes.iter().rev() {
+            let b: Vec<Boolean<ConstraintF>> = byte.to_bits_le()?;
+            bits.extend(b);
+        }
+        Ok(UInt32::from_bits_le(&bits))
+    }
+
+    fn to_bytes_be(&self) -> Vec<UInt8<ConstraintF>> {
+        self.to_bits_le()
+            .chunks(8)
+            .rev()
+            .map(UInt8::from_bits_le)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use ark_bls12_377::Fr;
+    use ark_r1cs_std::{bits::uint32::UInt32, R1CSVar};
+    use ark_std::rand::Rng;
+
+    const NUM_TESTS: usize = 10_000;
+
+    #[test]
+    fn test_shr() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = rng.r#gen::<u32>();
+            let by = rng.r#gen::<usize>() % 32;
+            assert_eq!(UInt32::<Fr>::constant(x).shr(by).value().unwrap(), x >> by);
+        }
+    }
+
+    #[test]
+    fn test_bitand() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = rng.r#gen::<u32>();
+            let y = rng.r#gen::<u32>();
+            assert_eq!(
+                UInt32::<Fr>::constant(x)
+                    .bitand(&UInt32::constant(y))
+                    .unwrap()
+                    .value()
+                    .unwrap(),
+                x & y
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_from_bytes_be() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = UInt32::<Fr>::constant(rng.r#gen::<u32>());
+            let bytes = x.to_bytes_be();
+            let y = UInt32::from_bytes_be(&bytes).unwrap();
+            assert_eq!(x.value(), y.value());
+        }
+    }
+}

--- a/src/transaction_integrity_gadget/constraints.rs
+++ b/src/transaction_integrity_gadget/constraints.rs
@@ -1,0 +1,244 @@
+//! Gadget to enforce the integrity of the transaction data
+
+use std::borrow::Borrow;
+use std::marker::PhantomData;
+use std::result::Result;
+
+use crate::sha256::constraints::DigestVar;
+use ark_ff::PrimeField;
+use ark_r1cs_std::{
+    alloc::AllocVar,
+    eq::EqGadget,
+    fields::fp::FpVar,
+    prelude::{Boolean, ToBytesGadget},
+    uint8::UInt8,
+    uint64::UInt64,
+};
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+
+use crate::constraints::{
+    script::ScriptVar,
+    sighash_cache::SigHashCacheVar,
+    tx::{TxVar, TxVarConfig},
+};
+use crate::transaction_integrity_gadget::utils::{get_chunk_size, to_fp_chunks};
+use crate::transaction_integrity_gadget::{TransactionIntegrityConfig, TransactionIntegrityTag};
+
+/// The R1CS version [TransactionIntegrityTag]
+/// It is a a vector because the tag needs to be chunked according to
+/// the bit size of the modulus over which F is defined
+pub struct TransactionIntegrityTagVar<F: PrimeField> {
+    pub inner: Vec<FpVar<F>>,
+}
+
+/// The gadget version of [TransactionIntegrityScheme](crate::transaction_integrity_gadget::TransactionIntegrityScheme)
+pub struct TransactionIntegrityGadget<F: PrimeField, P: TransactionIntegrityConfig> {
+    _ti_structure: PhantomData<P>,
+    _field: PhantomData<F>,
+}
+
+impl<F: PrimeField> TransactionIntegrityTagVar<F> {
+    /// Convert the FpVar elements of the tag into their byte representation
+    pub fn to_bytes(&self) -> Result<Vec<Vec<UInt8<F>>>, SynthesisError> {
+        let chunk_size = get_chunk_size::<F>();
+        let mut result: Vec<Vec<UInt8<F>>> = Vec::new();
+        for fp in self.inner.iter() {
+            result.push(fp.to_bytes()?[..chunk_size].to_vec());
+        }
+
+        Ok(result)
+    }
+}
+
+impl<F: PrimeField> AllocVar<TransactionIntegrityTag, F> for TransactionIntegrityTagVar<F> {
+    fn new_variable<T: Borrow<TransactionIntegrityTag>>(
+        cs: impl Into<Namespace<F>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: ark_r1cs_std::prelude::AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        let ns = cs.into();
+        let cs = ns.cs();
+
+        let tag: TransactionIntegrityTag = f().map(|t| t.borrow().clone())?;
+        let mut inner: Vec<FpVar<F>> = Vec::new();
+        for chunk in to_fp_chunks(&tag.inner).iter() {
+            inner.push(FpVar::<F>::new_variable(cs.clone(), || Ok(chunk), mode)?);
+        }
+
+        Ok(Self { inner })
+    }
+}
+
+impl<F: PrimeField> EqGadget<F> for TransactionIntegrityTagVar<F> {
+    fn is_eq(&self, other: &Self) -> std::result::Result<Boolean<F>, SynthesisError> {
+        self.inner.is_eq(&other.inner)
+    }
+}
+
+impl<F: PrimeField, P: TransactionIntegrityConfig + TxVarConfig + Clone>
+    TransactionIntegrityGadget<F, P>
+{
+    /// Verify the integrity of a tag
+    pub fn verify(
+        _cs: ConstraintSystemRef<F>,
+        tx: &TxVar<F, P>,
+        prev_lock_script: &ScriptVar<F>,
+        prev_amount: &UInt64<F>,
+        sighash_cache: &mut SigHashCacheVar<F>,
+        tag: &TransactionIntegrityTagVar<F>,
+    ) -> Result<(), SynthesisError> {
+        // Validate data against the configuration
+        assert_eq!(
+            prev_lock_script.0.len(),
+            P::LEN_PREV_LOCK_SCRIPT,
+            "The length of the previous locking script: {} is different from the one set in the parameters: P::LEN_PREV_LOCK_SCRIPT = {}",
+            prev_lock_script.0.len(),
+            P::LEN_PREV_LOCK_SCRIPT
+        );
+        // Compute the tag from `tx`, `prev_lock_script` and `prev_amount`
+        let computed_tag: DigestVar<F> = tx.sighash(
+            P::N_INPUT,
+            prev_lock_script,
+            prev_amount,
+            &P::SIGHASH_FLAG,
+            sighash_cache,
+        )?;
+
+        let chunk_size = get_chunk_size::<F>();
+        let mut is_valid_tag: Vec<Boolean<F>> = Vec::new();
+        for (public, computed) in tag
+            .to_bytes()?
+            .iter()
+            .zip(computed_tag.0.chunks_exact(chunk_size))
+        {
+            is_valid_tag.push(public.is_eq(computed)?);
+        }
+
+        Boolean::<F>::kary_and(&is_valid_tag)?.enforce_equal(&Boolean::<F>::TRUE)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_gang::address::addr_decode;
+    use chain_gang::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID, SigHashCache};
+
+    use chain_gang::messages::{OutPoint, Tx, TxIn, TxOut};
+    use chain_gang::network::Network;
+    use chain_gang::transaction::p2pkh;
+    use hex;
+
+    use ark_bls12_381::Fq as F;
+
+    use ark_relations::r1cs::ConstraintSystem;
+
+    use chain_gang::script::Script;
+    use chain_gang::util::Hash256;
+
+    use crate::transaction_integrity_gadget::{
+        TransactionIntegrityConfig, TransactionIntegrityScheme,
+    };
+
+    #[derive(Clone)]
+    struct Config;
+    impl TxVarConfig for Config {
+        const N_INPUTS: usize = 1;
+        const N_OUTPUTS: usize = 2;
+        const LEN_UNLOCK_SCRIPTS: &[usize] = &[0];
+        const LEN_LOCK_SCRIPTS: &[usize] = &[0x19, 0x19];
+    }
+
+    impl TransactionIntegrityConfig for Config {
+        const N_INPUT: usize = 0;
+        const LEN_PREV_LOCK_SCRIPT: usize = 0x19;
+        const SIGHASH_FLAG: u8 = SIGHASH_ALL | SIGHASH_FORKID;
+    }
+
+    fn test_ti_verify(prev_amount_tag: u64, prev_amount_allocated: u64) -> ConstraintSystemRef<F> {
+        let prev_lock_script =
+            Script(hex::decode("76a91402b74813b047606b4b3fbdfb1a6e8e053fdb8dab88ac").unwrap());
+        let addr = "mfmKD4cP6Na7T8D87XRSiR7shA1HNGSaec";
+        let hash160 = addr_decode(addr, Network::BSV_Testnet).unwrap().0;
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: Hash256::decode(
+                        "f671dc000ad12795e86b59b27e0c367d9b026bbd4141c227b9285867a53bb6f7",
+                    )
+                    .unwrap(),
+                    index: 0,
+                },
+                unlock_script: Script(vec![]),
+                sequence: 0,
+            }],
+            outputs: vec![
+                TxOut {
+                    satoshis: 100,
+                    lock_script: p2pkh::create_lock_script(&hash160),
+                },
+                TxOut {
+                    satoshis: 259899900,
+                    lock_script: p2pkh::create_lock_script(&hash160),
+                },
+            ],
+            lock_time: 0,
+        };
+        let mut cache = SigHashCache::new();
+
+        // TI tag
+        let tag = TransactionIntegrityScheme::<Config>::commit(
+            &tx,
+            &prev_lock_script,
+            prev_amount_tag,
+            &mut cache,
+        );
+
+        let cs = ConstraintSystem::<F>::new_ref();
+        let allocated_tag =
+            TransactionIntegrityTagVar::<F>::new_input(cs.clone(), || Ok(tag)).unwrap();
+        let allocated_tx = TxVar::<F, Config>::new_input(cs.clone(), || Ok(tx)).unwrap();
+        let allocated_prev_lock_script =
+            ScriptVar::<F>::new_input(cs.clone(), || Ok(prev_lock_script)).unwrap();
+        let allocated_prev_amount =
+            UInt64::<F>::new_input(cs.clone(), || Ok(prev_amount_allocated)).unwrap();
+        let mut allocated_cache = SigHashCacheVar::<F>::new();
+        TransactionIntegrityGadget::<F, Config>::verify(
+            cs.clone(),
+            &allocated_tx,
+            &allocated_prev_lock_script,
+            &allocated_prev_amount,
+            &mut allocated_cache,
+            &allocated_tag,
+        )
+        .unwrap();
+
+        let is_verified = cs.is_satisfied().unwrap();
+        assert!(is_verified);
+
+        cs
+    }
+
+    #[test]
+    fn test_ti_verify_is_ok() {
+        test_ti_verify(2600000, 2600000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_ti_verify_fails() {
+        test_ti_verify(2600000, 26);
+    }
+
+    #[test]
+    fn print_constraints() {
+        let cs = test_ti_verify(2600000, 2600000);
+        dbg!(
+            "The number of constaints for the TI gadget are: {}",
+            cs.num_constraints()
+        );
+    }
+}

--- a/src/transaction_integrity_gadget/mod.rs
+++ b/src/transaction_integrity_gadget/mod.rs
@@ -1,0 +1,82 @@
+//! Gadget to enforce the integrity of the transaction data
+
+use std::marker::PhantomData;
+
+use chain_gang::{
+    messages::Tx,
+    script::Script,
+    transaction::sighash::{SigHashCache, sighash},
+};
+
+pub mod constraints;
+pub mod utils;
+
+/// Configuration of the Transaction Integrity scheme
+pub trait TransactionIntegrityConfig {
+    /// The length of the locking script used to construct the sighash
+    const LEN_PREV_LOCK_SCRIPT: usize;
+    /// The index of the input for which we construct the sighash
+    const N_INPUT: usize;
+    /// The sighash flag used to construct the sighash
+    const SIGHASH_FLAG: u8;
+}
+
+/// The Transaction Integrity Scheme
+pub struct TransactionIntegrityScheme<P: TransactionIntegrityConfig> {
+    _ti_structure: PhantomData<P>,
+}
+
+/// The Transaction Integrity Tag
+#[derive(Clone, Debug, Eq, Default)]
+pub struct TransactionIntegrityTag {
+    pub inner: [u8; 32],
+}
+
+impl PartialEq for TransactionIntegrityTag {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<P: TransactionIntegrityConfig> TransactionIntegrityScheme<P> {
+    /// Generate a tag
+    pub fn commit(
+        tx: &Tx,
+        prev_lock_script: &Script,
+        prev_amount: u64,
+        sighash_cache: &mut SigHashCache,
+    ) -> TransactionIntegrityTag {
+        // Validate data against the configuration
+        assert_eq!(
+            prev_lock_script.0.len(),
+            P::LEN_PREV_LOCK_SCRIPT,
+            "The length of the previous locking script: {} is different from the one set in the parameters: P::LEN_PREV_LOCK_SCRIPT = {}",
+            prev_lock_script.0.len(),
+            P::LEN_PREV_LOCK_SCRIPT
+        );
+
+        let sighash = sighash(
+            tx,
+            P::N_INPUT,
+            &prev_lock_script.0,
+            prev_amount as i64,
+            P::SIGHASH_FLAG,
+            sighash_cache,
+        )
+        .unwrap();
+
+        TransactionIntegrityTag { inner: sighash.0 }
+    }
+
+    /// Verify the validity of a tag
+    pub fn verify(
+        tx: &Tx,
+        prev_lock_script: &Script,
+        prev_amount: u64,
+        sighash_cache: &mut SigHashCache,
+        tag: TransactionIntegrityTag,
+    ) -> bool {
+        TransactionIntegrityScheme::<P>::commit(tx, prev_lock_script, prev_amount, sighash_cache)
+            == tag
+    }
+}


### PR DESCRIPTION
Export SHA256 R1CS constraints from `ark_crypto_primitives`. This helps handling dependencies.