### PR TITLE
Ark 3.0 update pcd dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "ark-pcd"
 version = "0.1.0"
-source = "git+https://github.com/BarbacoviF/pcd.git?branch=barbacovif%2Fuse-short-weierstrass-curve#1bd8f435cfaff4dff65680270128a035cbbe4d2c"
+source = "git+https://github.com/nchain-innovation/pcd.git?branch=teranodegroup%2Fuse-short-weierstrass-curve#1bd8f435cfaff4dff65680270128a035cbbe4d2c"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 
-ark-pcd = { git = "https://github.com/BarbacoviF/pcd.git", branch = "barbacovif/use-short-weierstrass-curve", version = "0.1.0" }
+ark-pcd = { git = "https://github.com/nchain-innovation/pcd.git", branch = "teranodegroup/use-short-weierstrass-curve", version = "0.1.0" }
 ark-mnt4-753 = {version = "0.3.0", features = ["r1cs"]}
 ark-mnt6-753 = {version = "0.3.0", features = ["r1cs"]}
 ark-std = "0.3.0"


### PR DESCRIPTION
Update the `pcd` dependency to the organisation fork.